### PR TITLE
Fix `nodejs` version in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -53,6 +53,8 @@ jobs:
       with:
         ruby-version: 3.1
     - uses: actions/setup-node@v1
+      with:
+        node-version: '16'
     - name: Check markdown files using `markdownlint`
       run: |
         npm install -g markdownlint-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 * Fix minor rubocop issue after upgrade rubocop to `v1.24.0`
 * Remove `ruby-2.5` from CI since it's EOLed
 
+### Fixes
+
+* Fix `nodejs` version in CI
+
 ## 1.1.0 (2020-12-29)
 
 ### New Features


### PR DESCRIPTION
Without it `markdownlint` started to fail